### PR TITLE
Fix maven errors caused by Elasticsearch conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Run the class `fi.maanmittauslaitos.pta.search.api.Application` from the project
 
 Open a browser window with the URL http://localhost:8080
 
+## Testing
+
+In project pta-intelligent-search-qa there are integration tests that depend on data generated in projects pta-intelligent-search-harvester and pta-intelligent-search-api
+by using exec-maven-plugin. In order to run the tests, those projects should be compiled and packaged first. The simplest way verify that all is working is to run `mvn clean install` at the root of the project.
+
 ## Updating spatial regions
 
 Databases (geoJSON files) containing the bounding boxes of Finnish municipalities, sub regions and regions 

--- a/pta-intelligent-search-api/pom.xml
+++ b/pta-intelligent-search-api/pom.xml
@@ -89,7 +89,7 @@
 				<artifactId>exec-maven-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>my-execution</id>
+						<id>generate-qa-test-resource</id>
 						<phase>prepare-package</phase>
 						<goals>
 							<goal>java</goal>

--- a/pta-intelligent-search-harvester/pom.xml
+++ b/pta-intelligent-search-harvester/pom.xml
@@ -84,7 +84,7 @@
 				<artifactId>exec-maven-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>my-execution</id>
+						<id>generate-qa-test-resource</id>
 						<phase>prepare-package</phase>
 						<goals>
 							<goal>java</goal>

--- a/pta-intelligent-search-harvester/src/main/java/fi/maanmittauslaitos/pta/search/utils/Region.java
+++ b/pta-intelligent-search-harvester/src/main/java/fi/maanmittauslaitos/pta/search/utils/Region.java
@@ -1,7 +1,7 @@
 package fi.maanmittauslaitos.pta.search.utils;
 
 public interface Region {
-	public Double getArea();
+	Double getArea();
 
 	Double getIntersection(Region r2);
 

--- a/pta-intelligent-search-qa/pom.xml
+++ b/pta-intelligent-search-qa/pom.xml
@@ -20,60 +20,6 @@
 	<dependencies>
 		<dependency>
 			<groupId>nls.fi</groupId>
-			<artifactId>pta-intelligent-search-harvester</artifactId>
-			<version>0.9-SNAPSHOT</version>
-			<exclusions>
-				<exclusion>
-					<groupId>fi.nationallibrary</groupId>
-					<artifactId>maui</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>nls.fi</groupId>
-					<artifactId>pta-intelligent-search-metadata-annotation</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>log4j</groupId>
-					<artifactId>log4j</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-log4j12</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>jcl-over-slf4j</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>nls.fi</groupId>
-			<artifactId>pta-intelligent-search-api</artifactId>
-			<version>0.9-SNAPSHOT</version>
-			<exclusions>
-				<exclusion>
-					<groupId>fi.nationallibrary</groupId>
-					<artifactId>maui</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>nls.fi</groupId>
-					<artifactId>pta-intelligent-search-metadata-annotation</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>log4j</groupId>
-					<artifactId>log4j</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-log4j12</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>jcl-over-slf4j</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>nls.fi</groupId>
 			<artifactId>pta-intelligent-search-elasticsearch</artifactId>
 			<version>0.9-SNAPSHOT</version>
 		</dependency>
@@ -102,4 +48,44 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>process-remote-resources</id>
+						<goals>
+							<goal>unpack</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>nls.fi</groupId>
+									<artifactId>pta-intelligent-search-elasticsearch</artifactId>
+									<version>0.9-SNAPSHOT</version>
+									<includes>**/index.json</includes>
+								</artifactItem>
+								<artifactItem>
+									<groupId>nls.fi</groupId>
+									<artifactId>pta-intelligent-search-harvester</artifactId>
+									<version>0.9-SNAPSHOT</version>
+									<includes>**/generatedResourceMetadata.zip</includes>
+								</artifactItem>
+								<artifactItem>
+									<groupId>nls.fi</groupId>
+									<artifactId>pta-intelligent-search-api</artifactId>
+									<version>0.9-SNAPSHOT</version>
+									<includes>**/testcase*.json</includes>
+								</artifactItem>
+							</artifactItems>
+							<outputDirectory>${project.build.directory}/classes/</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/pta-intelligent-search-qa/src/test/java/fi/maanmittauslaitos/pta/search/integration/IsThereJarHell.java
+++ b/pta-intelligent-search-qa/src/test/java/fi/maanmittauslaitos/pta/search/integration/IsThereJarHell.java
@@ -1,9 +1,6 @@
 package fi.maanmittauslaitos.pta.search.integration;
 
-import static org.junit.Assert.*;
-
 import org.elasticsearch.bootstrap.JarHell;
-import org.junit.Before;
 import org.junit.Test;
 
 public class IsThereJarHell {


### PR DESCRIPTION
After #1, the command `mvn clean install` runned from the root of the project caused errors in pta-intelligent-search-qa module. This PR fixes these errors by using maven-dependency-plugin instead of direct dependencies.