### PR TITLE
Make CSW parser selectors more liberal

### DIFF
--- a/pta-intelligent-search-metadata-extractor/src/main/java/fi/maanmittauslaitos/pta/search/metadata/ISOMetadataExtractorConfigurationFactory.java
+++ b/pta-intelligent-search-metadata-extractor/src/main/java/fi/maanmittauslaitos/pta/search/metadata/ISOMetadataExtractorConfigurationFactory.java
@@ -1,9 +1,5 @@
 package fi.maanmittauslaitos.pta.search.metadata;
 
-import java.util.List;
-
-import javax.xml.parsers.ParserConfigurationException;
-
 import fi.maanmittauslaitos.pta.search.documentprocessor.DocumentProcessingConfiguration;
 import fi.maanmittauslaitos.pta.search.documentprocessor.DocumentProcessor;
 import fi.maanmittauslaitos.pta.search.documentprocessor.DocumentProcessorFactory;
@@ -12,184 +8,194 @@ import fi.maanmittauslaitos.pta.search.documentprocessor.XPathCustomExtractor;
 import fi.maanmittauslaitos.pta.search.documentprocessor.XPathFieldExtractorConfiguration;
 import fi.maanmittauslaitos.pta.search.documentprocessor.XPathFieldExtractorConfiguration.FieldExtractorType;
 
+import javax.xml.parsers.ParserConfigurationException;
+import java.util.List;
+
+import static fi.maanmittauslaitos.pta.search.metadata.utils.XPathHelper.doesntMatch;
+import static fi.maanmittauslaitos.pta.search.metadata.utils.XPathHelper.matches;
+
 
 public class ISOMetadataExtractorConfigurationFactory {
 	private DocumentProcessorFactory documentProcessorFactory = new DocumentProcessorFactory();
-	
+
 	public void setDocumentProcessorFactory(DocumentProcessorFactory documentProcessorFactory) {
 		this.documentProcessorFactory = documentProcessorFactory;
 	}
-	
+
 	public DocumentProcessorFactory getDocumentProcessorFactory() {
 		return documentProcessorFactory;
 	}
-	
-	
-	public DocumentProcessingConfiguration createMetadataDocumentProcessingConfiguration() throws ParserConfigurationException
-	{
+
+
+	public DocumentProcessingConfiguration createMetadataDocumentProcessingConfiguration() throws ParserConfigurationException {
 		DocumentProcessingConfiguration configuration = new DocumentProcessingConfiguration();
 		configuration.getNamespaces().put("gmd", "http://www.isotc211.org/2005/gmd");
 		configuration.getNamespaces().put("gco", "http://www.isotc211.org/2005/gco");
 		configuration.getNamespaces().put("srv", "http://www.isotc211.org/2005/srv");
 		configuration.getNamespaces().put("gmx", "http://www.isotc211.org/2005/gmx");
-		
+
 		configuration.getNamespaces().put("xlink", "http://www.w3.org/1999/xlink");
-		
-		
+
+
 		List<FieldExtractorConfiguration> extractors = configuration.getFieldExtractors();
-		
+
 		// Id extractor
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.ID,
 				FieldExtractorType.FIRST_MATCHING_VALUE,
 				"//gmd:fileIdentifier/*/text()"));
-		
+
 		// Title extractors
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.TITLE,
 				FieldExtractorType.FIRST_MATCHING_VALUE,
 				"(" +
-				  "//gmd:identificationInfo/*/gmd:citation/*/gmd:title//gmd:LocalisedCharacterString[@locale='#FI']" +
-				  "|" +
-				  "//gmd:identificationInfo/*/gmd:citation/*/gmd:title/*[self::gco:CharacterString]" +
-				")/text()"));
+						"//gmd:identificationInfo/*/gmd:citation/*/gmd:title//gmd:LocalisedCharacterString[" +
+						matches("@locale", "'#FI'") + "]" +
+						"|" +
+						"//gmd:identificationInfo/*/gmd:citation/*/gmd:title/*[self::gco:CharacterString]" +
+						")/text()"));
 
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.TITLE_SV,
 				FieldExtractorType.FIRST_MATCHING_VALUE,
 				"(" +
-				  "//gmd:identificationInfo/*/gmd:citation/*/gmd:title//gmd:LocalisedCharacterString[@locale='#SV']" +
-				")/text()"));
+						"//gmd:identificationInfo/*/gmd:citation/*/gmd:title//gmd:LocalisedCharacterString[" +
+						matches("@locale", "'#SV'") + "]" +
+						")/text()"));
 
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.TITLE_EN,
 				FieldExtractorType.FIRST_MATCHING_VALUE,
 				"(" +
-				  "//gmd:identificationInfo/*/gmd:citation/*/gmd:title//gmd:LocalisedCharacterString[@locale='#EN']" +
-				")/text()"));
+						"//gmd:identificationInfo/*/gmd:citation/*/gmd:title//gmd:LocalisedCharacterString[" +
+						matches("@locale", "'#EN'") + "])/text()"));
 
 		// Abstract extractors
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.ABSTRACT,
 				FieldExtractorType.FIRST_MATCHING_VALUE,
 				"(" +
-				  "//gmd:identificationInfo/*/gmd:abstract//gmd:LocalisedCharacterString[@locale='#FI']" +
-				  "|" +
-				  "//gmd:identificationInfo/*/gmd:abstract/*[self::gco:CharacterString]" +
-				")/text()"));
-		
+						"//gmd:identificationInfo/*/gmd:abstract//gmd:LocalisedCharacterString[" +
+						matches("@locale", "'#FI'") + "]" +
+						"|" +
+						"//gmd:identificationInfo/*/gmd:abstract/*[self::gco:CharacterString]" +
+						")/text()"));
+
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.ABSTRACT_SV,
 				FieldExtractorType.FIRST_MATCHING_VALUE,
 				"(" +
-				  "//gmd:identificationInfo/*/gmd:abstract//gmd:LocalisedCharacterString[@locale='#SV']" +
-				")/text()"));
+						"//gmd:identificationInfo/*/gmd:abstract//gmd:LocalisedCharacterString[" +
+						matches("@locale", "'#SV'") + "])/text()"));
 
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.ABSTRACT_EN,
 				FieldExtractorType.FIRST_MATCHING_VALUE,
 				"(" +
-				  "//gmd:identificationInfo/*/gmd:abstract//gmd:LocalisedCharacterString[@locale='#EN']" +
-				")/text()"));
+						"//gmd:identificationInfo/*/gmd:abstract//gmd:LocalisedCharacterString[" +
+						matches("@locale", "'#EN'") + "])/text()"));
 
 		// isService 
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.IS_SERVICE,
 				FieldExtractorType.TRUE_IF_MATCHES_OTHERWISE_FALSE,
 				"//gmd:hierarchyLevel/gmd:MD_ScopeCode["
-						+ "@codeList='http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode'"
+						+ matches("@codeList", "'http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode'")
 						+ " and "
-						+ "@codeListValue='service'"
+						+ matches("@codeListValue", "'service'")
 						+ "]"));
-		
-		
+
 		// isDataset
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.IS_DATASET,
 				FieldExtractorType.TRUE_IF_MATCHES_OTHERWISE_FALSE,
 				"//gmd:hierarchyLevel/gmd:MD_ScopeCode["
-						+ "@codeList='http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode'"
+						+ matches("@codeList", "'http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode'")
 						+ " and "
-						+ "(@codeListValue='dataset' or @codeListValue='series')"
+						+ "(" + matches("@codeListValue", "'dataset'") + " or " + matches("@codeListValue", "'series'") + ")"
 						+ "]"));
-		
+
+
 		// isAvoindata
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.IS_AVOINDATA,
 				FieldExtractorType.TRUE_IF_MATCHES_OTHERWISE_FALSE,
-				"//gmd:identificationInfo/*/gmd:descriptiveKeywords/*/gmd:keyword/*[text()='avoindata.fi']"));
+				"//gmd:identificationInfo/*/gmd:descriptiveKeywords/*/gmd:keyword/*[" +
+						matches("text()", "'avoindata.fi'") +
+						"]"));
 
 		// Topic categories
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.TOPIC_CATEGORIES,
 				FieldExtractorType.ALL_MATCHING_VALUES,
 				"//gmd:identificationInfo/*/gmd:topicCategory/gmd:MD_TopicCategoryCode/text()"));
-		
+
 		// Keywords
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.KEYWORDS_ALL,
 				FieldExtractorType.ALL_MATCHING_VALUES,
-				"//gmd:identificationInfo/*/gmd:descriptiveKeywords/*/gmd:keyword/gco:CharacterString[text()!='avoindata.fi']/text()"));
-		
+				"//gmd:identificationInfo/*/gmd:descriptiveKeywords/*/gmd:keyword/gco:CharacterString[" +
+						doesntMatch("text()", "'avoindata.fi'") + "]/text()"));
+
 		// Inspire themes
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.KEYWORDS_INSPIRE,
 				FieldExtractorType.ALL_MATCHING_VALUES,
-				"//gmd:identificationInfo/*/gmd:descriptiveKeywords/*[gmd:thesaurusName/gmd:CI_Citation/gmd:title/*/text() = 'GEMET - INSPIRE themes, version 1.0']/gmd:keyword/gco:CharacterString/text()"));
-		
+				"//gmd:identificationInfo/*/gmd:descriptiveKeywords/*[" +
+						matches("gmd:thesaurusName/gmd:CI_Citation/gmd:title/*/text()", "'GEMET - INSPIRE themes, version 1.0'") +
+						"]/gmd:keyword/gco:CharacterString/text()"));
+
 		// Distribution Formats
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.DISTRIBUTION_FORMATS,
 				FieldExtractorType.ALL_MATCHING_VALUES,
 				"//gmd:distributionInfo/*/gmd:distributionFormat/*/gmd:name/gco:*/text()"));
 
-		
+
 		// Datestamp
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.DATESTAMP,
 				FieldExtractorType.FIRST_MATCHING_VALUE,
 				"//gmd:MD_Metadata/gmd:dateStamp/*/text()"));
-	
-		
+
+
 		// Organisation names + roles
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.ORGANISATIONS,
 				new ResponsiblePartyXPathCustomExtractor(),
 				"//gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact/gmd:CI_ResponsibleParty"));
-		
+
 		// Geographic bounding box
 		extractors.add(createXPathExtractor(
 				ISOMetadataFields.GEOGRAPHIC_BOUNDING_BOX,
 				new GeographicBoundingBoxXPathCustomExtractor(),
 				"//gmd:MD_Metadata/gmd:identificationInfo/*/*[self::gmd:extent or self::srv:extent]/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox"));
-		
+
 		return configuration;
 	}
-	
-	public DocumentProcessor createMetadataDocumentProcessor() throws ParserConfigurationException
-	{
+
+	public DocumentProcessor createMetadataDocumentProcessor() throws ParserConfigurationException {
 		DocumentProcessingConfiguration configuration = createMetadataDocumentProcessingConfiguration();
 		return getDocumentProcessorFactory().createProcessor(configuration);
 	}
 
-	private FieldExtractorConfiguration createXPathExtractor(String field, FieldExtractorType type, String xpath)
-	{
+	private FieldExtractorConfiguration createXPathExtractor(String field, FieldExtractorType type, String xpath) {
 		XPathFieldExtractorConfiguration ret = new XPathFieldExtractorConfiguration();
 		ret.setField(field);
 		ret.setType(type);
 		ret.setXpath(xpath);
-		
+
 		return ret;
 	}
-	
-	private FieldExtractorConfiguration createXPathExtractor(String field, XPathCustomExtractor extractor, String xpath)
-	{
+
+	private FieldExtractorConfiguration createXPathExtractor(String field, XPathCustomExtractor extractor, String xpath) {
 		XPathFieldExtractorConfiguration ret = new XPathFieldExtractorConfiguration();
 		ret.setField(field);
 		ret.setType(FieldExtractorType.CUSTOM_CLASS);
 		ret.setXpath(xpath);
 		ret.setCustomExtractor(extractor);
-		
+
 		return ret;
 	}
 }

--- a/pta-intelligent-search-metadata-extractor/src/main/java/fi/maanmittauslaitos/pta/search/metadata/ResponsiblePartyXPathCustomExtractor.java
+++ b/pta-intelligent-search-metadata-extractor/src/main/java/fi/maanmittauslaitos/pta/search/metadata/ResponsiblePartyXPathCustomExtractor.java
@@ -1,18 +1,19 @@
 package fi.maanmittauslaitos.pta.search.metadata;
 
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathException;
-import javax.xml.xpath.XPathExpression;
-
+import fi.maanmittauslaitos.pta.search.documentprocessor.XPathCustomExtractor;
+import fi.maanmittauslaitos.pta.search.metadata.model.ResponsibleParty;
+import fi.maanmittauslaitos.pta.search.metadata.model.TextRewriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import fi.maanmittauslaitos.pta.search.documentprocessor.XPathCustomExtractor;
-import fi.maanmittauslaitos.pta.search.metadata.model.ResponsibleParty;
-import fi.maanmittauslaitos.pta.search.metadata.model.TextRewriter;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathException;
+import javax.xml.xpath.XPathExpression;
+
+import static fi.maanmittauslaitos.pta.search.metadata.utils.XPathHelper.matches;
 
 public class ResponsiblePartyXPathCustomExtractor implements XPathCustomExtractor {
 	private static Logger logger = LogManager.getLogger(ResponsiblePartyXPathCustomExtractor.class);
@@ -55,9 +56,11 @@ public class ResponsiblePartyXPathCustomExtractor implements XPathCustomExtracto
 		organisationName = (String)nameExpr.evaluate(node, XPathConstants.STRING);
 		
 		organisationName = getOrganisationNameRewriter().rewrite(organisationName);
-		
-		XPathExpression isoRoleExpr = 
-				xPath.compile("./gmd:role/gmd:CI_RoleCode[@codeList = 'http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_RoleCode']/@codeListValue");
+
+		XPathExpression isoRoleExpr =
+				xPath.compile("./gmd:role/gmd:CI_RoleCode[" +
+						matches("@codeList", "'http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_RoleCode'") +
+						"]/@codeListValue");
 		isoRole = (String)isoRoleExpr.evaluate(node, XPathConstants.STRING);
 		
 		if (logger.isTraceEnabled()) {

--- a/pta-intelligent-search-metadata-extractor/src/main/java/fi/maanmittauslaitos/pta/search/metadata/utils/XPathHelper.java
+++ b/pta-intelligent-search-metadata-extractor/src/main/java/fi/maanmittauslaitos/pta/search/metadata/utils/XPathHelper.java
@@ -1,0 +1,14 @@
+package fi.maanmittauslaitos.pta.search.metadata.utils;
+
+public class XPathHelper {
+
+	private static final String TO_LOWER = "'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'";
+
+	public static String matches(String attribute, String value) {
+		return String.format("translate(%s, " + TO_LOWER + ")=%s", attribute, value.toLowerCase());
+	}
+
+	public static String doesntMatch(String attribute, String value) {
+		return String.format("translate(%s, " + TO_LOWER + ")!=%s", attribute, value.toLowerCase());
+	}
+}

--- a/pta-intelligent-search-metadata-extractor/src/test/java/fi/maanmittauslaitos/pta/search/metadata/ISOMetadataExtractor_IsServiceTest.java
+++ b/pta-intelligent-search-metadata-extractor/src/test/java/fi/maanmittauslaitos/pta/search/metadata/ISOMetadataExtractor_IsServiceTest.java
@@ -1,10 +1,9 @@
 package fi.maanmittauslaitos.pta.search.metadata;
 
-import static org.junit.Assert.*;
-
+import fi.maanmittauslaitos.pta.search.documentprocessor.Document;
 import org.junit.Test;
 
-import fi.maanmittauslaitos.pta.search.documentprocessor.Document;
+import static org.junit.Assert.assertEquals;
 
 public class ISOMetadataExtractor_IsServiceTest extends BaseMetadataExtractorTest {
 
@@ -15,7 +14,16 @@ public class ISOMetadataExtractor_IsServiceTest extends BaseMetadataExtractorTes
 		Boolean isService = document.getValue(ISOMetadataFields.IS_SERVICE, Boolean.class);
 		assertEquals(Boolean.TRUE, isService);
 	}
-	
+
+	@Test
+	public void testStatFiWFSModifiedIsService() throws Exception {
+		Document document = createStatFiWFS_modified();
+
+		Boolean isService = document.getValue(ISOMetadataFields.IS_SERVICE, Boolean.class);
+		assertEquals(Boolean.TRUE, isService);
+	}
+
+
 	@Test
 	public void testMaastotietokantaIsNotService() throws Exception {
 		Document document = createMaastotietokantaDocument();

--- a/pta-intelligent-search-metadata-extractor/src/test/resources/c3c05280-b1cd-4ae6-9c1a-26a8d9f7201d_modified.xml
+++ b/pta-intelligent-search-metadata-extractor/src/test/resources/c3c05280-b1cd-4ae6-9c1a-26a8d9f7201d_modified.xml
@@ -10,10 +10,8 @@
    - added second organisation (owner, different name, localised name switched to swedish)
   -->
 <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
-                 xmlns:gts="http://www.isotc211.org/2005/gts"
                  xmlns:xlink="http://www.w3.org/1999/xlink"
                  xmlns:gco="http://www.isotc211.org/2005/gco"
-                 xmlns:gml="http://www.opengis.net/gml"
                  xmlns:srv="http://www.isotc211.org/2005/srv"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd&#xA;                  http://www.isotc211.org/2005/gmx http://www.isotc211.org/2005/gmx/gmx.xsd&#xA;                  http://www.isotc211.org/2005/srv http://schemas.opengis.net/iso/19139/20060504/srv/srv.xsd&#xA;  ">
@@ -25,7 +23,7 @@
   </gmd:language>
   <gmd:hierarchyLevel>
       <gmd:MD_ScopeCode codeListValue="service"
-                        codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"/>
+                        codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_ScopeCode"/>
   </gmd:hierarchyLevel>
   <gmd:contact>
       <gmd:CI_ResponsibleParty>
@@ -114,7 +112,7 @@
          </gmd:characterEncoding>
       </gmd:PT_Locale>
   </gmd:locale>
-  <gmd:identificationInfo xmlns:date="http://exslt.org/dates-and-times">
+   <gmd:identificationInfo>
       <srv:SV_ServiceIdentification>
          <gmd:citation>
             <gmd:CI_Citation>
@@ -525,7 +523,7 @@ Då uppgifterna används, ska de allmänna användarvillkoren iakttas
             <gmd:DQ_Scope>
                <gmd:level>
                   <gmd:MD_ScopeCode codeListValue="service"
-                                    codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"/>
+                                    codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_ScopeCode"/>
                </gmd:level>
             </gmd:DQ_Scope>
          </gmd:scope>


### PR DESCRIPTION
This proposal adds case-insensitive xPath expressions in equality checks when parsing CSW files. 

For example if the codeList attribute url contains `Codelist` while it should be `codelist` like in snippet below, the selector would not mind.
```xml
<gmd:hierarchyLevel>  
  <gmd:MD_ScopeCode codeListValue="service"
 codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/ML_gmxCodelists.xml#MD_ScopeCode"/>
</gmd:hierarchyLevel>
```
