### PR TITLE
Change csw metadata type matching to just match the end of the url

### DIFF
--- a/pta-intelligent-search-metadata-extractor/src/main/java/fi/maanmittauslaitos/pta/search/metadata/ISOMetadataExtractorConfigurationFactory.java
+++ b/pta-intelligent-search-metadata-extractor/src/main/java/fi/maanmittauslaitos/pta/search/metadata/ISOMetadataExtractorConfigurationFactory.java
@@ -10,8 +10,7 @@ import fi.maanmittauslaitos.pta.search.documentprocessor.FieldExtractorConfigura
 import javax.xml.parsers.ParserConfigurationException;
 import java.util.List;
 
-import static fi.maanmittauslaitos.pta.search.metadata.utils.XPathHelper.doesntMatch;
-import static fi.maanmittauslaitos.pta.search.metadata.utils.XPathHelper.matches;
+import static fi.maanmittauslaitos.pta.search.metadata.utils.XPathHelper.*;
 
 
 public class ISOMetadataExtractorConfigurationFactory extends MetadataExtractorConfigurationFactory {
@@ -92,7 +91,7 @@ public class ISOMetadataExtractorConfigurationFactory extends MetadataExtractorC
 				ResultMetadataFields.IS_SERVICE,
 				FieldExtractorType.TRUE_IF_MATCHES_OTHERWISE_FALSE,
 				"//gmd:hierarchyLevel/gmd:MD_ScopeCode["
-						+ matches("@codeList", "'http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode'")
+                        + endsWith("@codeList", "'gmxCodelists.xml#MD_ScopeCode'", true)
 						+ " and "
 						+ matches("@codeListValue", "'service'")
 						+ "]"));
@@ -102,7 +101,7 @@ public class ISOMetadataExtractorConfigurationFactory extends MetadataExtractorC
 				ResultMetadataFields.IS_DATASET,
 				FieldExtractorType.TRUE_IF_MATCHES_OTHERWISE_FALSE,
 				"//gmd:hierarchyLevel/gmd:MD_ScopeCode["
-						+ matches("@codeList", "'http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode'")
+                        + endsWith("@codeList", "'gmxCodelists.xml#MD_ScopeCode'", true)
 						+ " and "
 						+ "(" + matches("@codeListValue", "'dataset'") + " or " + matches("@codeListValue", "'series'") + ")"
 						+ "]"));

--- a/pta-intelligent-search-metadata-extractor/src/main/java/fi/maanmittauslaitos/pta/search/metadata/utils/XPathHelper.java
+++ b/pta-intelligent-search-metadata-extractor/src/main/java/fi/maanmittauslaitos/pta/search/metadata/utils/XPathHelper.java
@@ -11,4 +11,18 @@ public class XPathHelper {
 	public static String doesntMatch(String attribute, String value) {
 		return String.format("translate(%s, " + TO_LOWER + ")!=%s", attribute, value.toLowerCase());
 	}
+
+	/**
+	 * Matches that the given attribute's value ends with the given value
+	 * @param attribute the attribute which value you want to match to
+	 * @param value to match to. Note that the given value should be wrapped in single quotes,
+	 *                 i.e. to match the end of the attribute's value to "foobar", you need to pass "'foobar'"
+	 * @param isIgnoreCase defines if case should be ignored when matching
+	 * @return
+	 */
+	public static String endsWith(String attribute, String value, boolean isIgnoreCase) {
+		String endString = String.format("substring(%s, string-length(%s) - string-length(%s) + 1)", attribute, attribute, value);
+
+		return isIgnoreCase ? matches(endString, value) : String.format("%s = %s", endString, value);
+	}
 }


### PR DESCRIPTION
The type of the csw metadata is deduced from a xml node containing a codeList and a codeListValue. The url for the codeList can vary depending on the metadata, so this PR includes a change to just match the end of the url that contains the filename and xml node data model. 

Below two observed variations of the url

```
<gmd:MD_ScopeCode codeListValue="service" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode" />
```

```
<gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset">dataset</gmd:MD_ScopeCode>
```